### PR TITLE
configure monorepo packages

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,3 @@
+# `@with-heart/xstate-websocket-client`
+
+A `WebSocket` client built with XState

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@with-heart/xstate-websocket-client",
+  "version": "0.0.0",
+  "description": "WebSocket client built with XState",
+  "scripts": {},
+  "keywords": [
+    "websocket",
+    "websockets",
+    "sockets",
+    "client",
+    "xstate"
+  ],
+  "author": "with-heart <with.heart+git@pm.me>",
+  "license": "MIT",
+  "repository": "https://github.com/with-heart/xstate-websockets/blob/main/client/README.md",
+  "bugs": "https://github.com/with-heart/xstate-websockets/issues"
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'server'
+  - 'client'

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,3 @@
+# `@with-heart/xstate-websocket-server`
+
+A `WebSocket` server built with XState

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@with-heart/xstate-websocket-server",
+  "version": "0.0.0",
+  "description": "WebSocket server built with XState",
+  "scripts": {},
+  "keywords": [
+    "websocket",
+    "websockets",
+    "sockets",
+    "client",
+    "xstate"
+  ],
+  "author": "with-heart <with.heart+git@pm.me>",
+  "license": "MIT",
+  "repository": "https://github.com/with-heart/xstate-websockets/blob/main/server/README.md",
+  "bugs": "https://github.com/with-heart/xstate-websockets/issues"
+}


### PR DESCRIPTION
This PR configures `pnpm` to [treat our workspace as a monorepo](https://pnpm.io/workspaces). It also creates the `server` and `client` packages.